### PR TITLE
Adds 'ElloCerts.isPublic', used in the Ello-iOS specs to adapt its specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.2
+osx_image: xcode7.3
 language: objective-c
 before_install:
   - bundle install

--- a/ElloOSSCerts.podspec
+++ b/ElloOSSCerts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ElloOSSCerts'
-  s.version          = '1.0.1'
+  s.version          = '1.1.0'
   s.summary          = 'The certs for the Ello iOS app.'
   s.homepage         = 'https://github.com/ello/Ello-OSS-iOS-Certs'
   s.license          = 'Private'

--- a/Example/Tests/ElloCertsSpec.swift
+++ b/Example/Tests/ElloCertsSpec.swift
@@ -11,6 +11,9 @@ class ElloCertsSpec: QuickSpec {
             it("should be empty") {
                 expect(ElloCerts.policy["ello.co"]).to(beNil())
             }
+            it("should be public") {
+                expect(ElloCerts.isPublic) == true
+            }
         }
     }
 }

--- a/Pod/Classes/ElloCerts.swift
+++ b/Pod/Classes/ElloCerts.swift
@@ -3,5 +3,6 @@ import Alamofire
 
 
 public class ElloCerts {
+    public static let isPublic = true
     public static let policy: [String: ServerTrustPolicy] = [:]
 }


### PR DESCRIPTION
The private repo returns `false`, the public one returns `true`.
